### PR TITLE
Explicitly depend on aws-sdk v1

### DIFF
--- a/ec2-blackout.gemspec
+++ b/ec2-blackout.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.summary       = Ec2::Blackout.summary
   gem.homepage      = "https://github.com/srbartlett/ec2-blackout"
   gem.add_dependency 'commander'
-  gem.add_dependency 'aws-sdk'
+  gem.add_dependency 'aws-sdk-v1', '~> 1.0'
   gem.add_dependency 'colorize'
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/ec2-blackout.rb
+++ b/lib/ec2-blackout.rb
@@ -1,9 +1,8 @@
 require "ec2-blackout/version"
 require 'commander'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'ec2-blackout/options'
 require 'ec2-blackout/auto_scaling_group'
 require 'ec2-blackout/ec2_instance'
 require 'ec2-blackout/startup'
 require 'ec2-blackout/shutdown'
-


### PR DESCRIPTION
ec2-blackout currently depends on aws-sdk version 1.x. This causes conflicts when it is pulled into projects using aws-sdk v2. To get around this problem, AWS have published v1 under a different gem name (aws-sdk-v1) to allow both versions to co-exist.

This PR makes ec2-blackout depend explicitly on aws-sdk-v1, which allows it to be used in projects that are using aws-sdk v2.

Closes #4 